### PR TITLE
Changed catch-all URI path in h2o config from "" to "/".

### DIFF
--- a/pages/tutorials/quick-django-install.yml
+++ b/pages/tutorials/quick-django-install.yml
@@ -120,7 +120,7 @@ We need to replace the default config file `/etc/h2o/h2o.conf` with our own:
     hosts:
       default:
         paths:
-          "":
+          "/":
             proxy.reverse.url: "http://[unix:/srv/www/gunicorn.sock]"
             proxy.preserve-host: ON
           "/static":
@@ -271,6 +271,12 @@ And at long last, we can ask `systemd` to start our socket service:
 
     :::console
     # systemctl enable --now gunicorn.socket
+
+Now let's confirm that the Django application is accessible, at least inside the server:
+
+    :::console
+    $ wget -O - http://localhost 2>/dev/null | grep title
+        <title>The install worked successfully! Congratulations!</title>
 
 Finally, to make sure it's all safe and reliable, we'll reboot:
 


### PR DESCRIPTION
Without this change, `wget http://localhost` returns a `400 Bad Request` with a message:

    Invalid HTTP request line: "GET  HTTP/1.1"

This is because gunicorn is expecting 3 space-separated components in the request line, e.g

    "GET / HTTP/1.1"

But the h2o proxy is only providing 2 space-separated components:

    "GET  HTTP/1.1"

https://github.com/benoitc/gunicorn/blob/master/gunicorn/http/message.py#L328